### PR TITLE
Fix invalid preselection of results mode

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -625,7 +625,7 @@ impl Render for RenderHTML {
         if only_files && (!params.use_autolist || params.autolist_wiki_server == AUTOLIST_COMMONS) {
             rows.push( "<div id='file_results' style='float:right;clear:right;' class='btn-group' data-toggle='buttons'>".to_string());
             rows.push( "<label class='btn btn-light active'><input type='radio' checked name='results_mode' value='titles' autocomplete='off' /><span tt='show_titles'></span></label>".to_string());
-            rows.push( "<label class='btn btn-light'><input type='radio' name='results_mode' value='thumbnails' checked autocomplete='off' /><span tt='show_thumbnails'></span></label>".to_string());
+            rows.push( "<label class='btn btn-light'><input type='radio' name='results_mode' value='thumbnails' autocomplete='off' /><span tt='show_thumbnails'></span></label>".to_string());
             rows.push("</div>".to_string());
         }
 


### PR DESCRIPTION
At the moment, both radio buttons for the results mode are marked `checked`. Thus, some browsers will select *Thumbnails* even though *Titles* is the default mode.