### PR TITLE
setPermalink() should execute if querystring is not empty

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -81,7 +81,7 @@ function setPermalink () {
 	$('span[name="psid"]').each ( function () { psid = $(this).text() ; } ) ;
 
 	var q = $("#querystring").text();
-	if ( q != '' ) return;
+	if ( q == '' ) return;
 
 	const params = new URLSearchParams(q);
 	// Removing auto-run


### PR DESCRIPTION
Restores the behavior lost after merging #118. Fixes #123 