### PR TITLE
Fix #132 by adjusting querystring processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,6 @@ dependencies = [
  "lazy_static",
  "mysql_async",
  "percent-encoding",
- "qstring",
  "rand",
  "rayon",
  "regex",
@@ -1759,15 +1758,6 @@ checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
 dependencies = [
  "idna 0.3.0",
  "psl-types",
-]
-
-[[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ wikibase = { git = "https://gitlab.com/tobias47n9e/wikibase_rs" }
 tokio = { version = "^1", features = ["macros","fs","sync"] }
 tokio-util = "*"
 hyper = { version = "^0.14", features = ["full"] }
-qstring = "*"
 futures = "*"
 
 [profile.release]

--- a/src/form_parameters.rs
+++ b/src/form_parameters.rs
@@ -27,12 +27,9 @@ impl FormParameters {
         Self { ..Default::default() }
     }
 
-    pub fn new_from_pairs(parameter_pairs: Vec<(&str, &str)>) -> Self {
+    pub fn new_from_pairs(parameter_pairs: HashMap<String, String>) -> Self {
         let mut ret = Self::new();
-        ret.params = parameter_pairs
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string().replace("+", " ")))
-            .collect();
+        ret.params = parameter_pairs;
         ret.ns = Self::ns_from_params(&ret.params);
         ret.legacy_parameters();
         ret

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ pub mod wdfist;
 
 use tokio::fs::File as TokioFile;
 use tokio_util::codec::{BytesCodec, FramedRead};
-use qstring::QString;
+use url::form_urlencoded;
 use crate::form_parameters::FormParameters;
 use app_state::AppState;
 use platform::{MyResponse, Platform, ContentType};
@@ -35,8 +35,9 @@ use hyper::service::{make_service_fn, service_fn};
 static NOTFOUND: &[u8] = b"Not Found";
 
 async fn process_form(parameters:&str, state: Arc<AppState>) -> MyResponse {
-    let parameter_pairs = QString::from(parameters) ;
-    let parameter_pairs = parameter_pairs.to_pairs() ;
+    let parameter_pairs = form_urlencoded::parse(parameters.as_bytes())
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
     let mut form_parameters = FormParameters::new_from_pairs ( parameter_pairs ) ;
 
     // Restart command?


### PR DESCRIPTION
The backend decodes querystrings with the `qstring` crate. However, that decodes both a plus sign and a URL-encoded plus sign to exactly the same thing, erasing the distinction between plus signs and spaces (see algesten/qstring#3). This patch instead uses the underlying `url` crate, which handles plus signs correctly.

This fix should be combined with #138, which fixes the frontend piece; however, merging just this one would correct the saving in the backend.