### PR TITLE
Load thumbnails lazily

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -740,7 +740,7 @@ impl Render for RenderHTML {
                     "{}/wiki/Special:Redirect/file/{}?width={}",
                     &server_url, &file, &thumnail_size
                 );
-                format!("<div class='card thumbcard'><a target='_blank' href='{}'><img class='card-img thumbcard-img' src='{}'/></a></div>",url,src)
+                format!("<div class='card thumbcard'><a target='_blank' href='{}'><img class='card-img thumbcard-img' src='{}' loading='lazy' /></a></div>",url,src)
             }
             None => String::new(),
         }


### PR DESCRIPTION
To reduce the page load time and usage of Wikipedia servers, defer loading thumbnails until they become visible in the viewport.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading