### PR TITLE
Add tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ url = "*"
 rayon = "*"
 htmlescape = "*"
 rand = "*"
-mysql_async = "*"
+mysql_async = { version = "*", features = ["tracing"] }
 reqwest = { version = "*", features = ["json"] }
 time = "^0.3"
 percent-encoding = "*"
@@ -28,6 +28,8 @@ tokio-util = "*"
 hyper = { version = "^0.14", features = ["full"] }
 qstring = "*"
 futures = "*"
+tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
+tracing = "0.1.40"
 
 [profile.release]
 lto = "fat"

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,7 @@ async fn process_request(mut req: Request<Body>,app_state:Arc<AppState>) -> Resu
 
 #[tokio::main]
 async fn main() -> Result<(),Error> {
+    tracing_subscriber::fmt::init();
 
     let basedir = env::current_dir()
         .expect("Can't get CWD")

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use tokio::sync::Mutex as TokioMutex;
 use futures::future::join_all;
+use tracing::{instrument, debug};
 use crate::app_state::AppState;
 use crate::datasource::*;
 use crate::datasource_database::{SourceDatabase, SourceDatabaseParameters};
@@ -8,7 +9,6 @@ use crate::form_parameters::FormParameters;
 use crate::pagelist::*;
 use crate::render::*;
 use crate::wdfist::*;
-use chrono::Local;
 use mysql_async::from_row;
 use mysql_async as my;
 use mysql_async::Value as MyValue;
@@ -194,6 +194,7 @@ impl Platform {
         ret
     }
 
+    #[instrument(skip_all, err(level = tracing::Level::INFO))]
     pub async fn run(&mut self) -> Result<(), String> {
         Platform::profile("begin run", None);
         let start_time = SystemTime::now();
@@ -312,14 +313,7 @@ impl Platform {
     }
 
     pub fn profile(label: &str, num: Option<usize>) {
-        if false {
-            println!(
-                "{} [{}]: {}",
-                Local::now().format("%Y-%m-%d %H:%M:%S"),
-                num.unwrap_or(0),
-                label,
-            );
-        }
+        debug!(num, "{}", label);
     }
 
     async fn post_process_result(&self, available_sources: &[String]) -> Result<(), String> {


### PR DESCRIPTION
To simplify debugging, we could use the [`tracing`](https://docs.rs/tracing/) crate, a structured logging and diagnostics system. As an example, I instrumented some calls to illustrate its usage. Some of the dependencies will emit events as well.

`RUST_LOG='info,petscan_rs=TRACE' cargo run`
![tracing](https://github.com/magnusmanske/petscan_rs/assets/20755228/b6a323da-ac00-46f3-84e7-5e5ed6768c2a)
